### PR TITLE
Update to julia1.6 & fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-os:
-  - linux
-  # - osx
+dist: bionic
 julia:
   - 1.0
   - 1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-    - g++-7.4
+    - g++-7
     - cmake
     - libboost-all-dev
     - build-essential
@@ -43,7 +43,7 @@ addons:
     - unzip
 
 env:
-  - CC=gcc-7.4 && CXX=g++-7.4
+  - CC=gcc-7 && CXX=g++-7
 
 script:
   - julia -e 'using Pkg; Pkg.activate(pwd()); Pkg.instantiate(); Pkg.build("ViZDoom");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-    - g++-4.9
+    - g++-7.4
     - cmake
     - libboost-all-dev
     - build-essential
@@ -43,7 +43,7 @@ addons:
     - unzip
 
 env:
-  - CC=gcc-4.9 && CXX=g++-4.9
+  - CC=gcc-7.4 && CXX=g++-7.4
 
 script:
   - julia -e 'using Pkg; Pkg.activate(pwd()); Pkg.instantiate(); Pkg.build("ViZDoom");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   # - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.6
   - nightly
 notifications:
   email: false

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[ViZDoom]
+git-tree-sha1 = "7d63ffbf41233f9167b8948641e0439e759a24bf"
+
+    [[ViZDoom.download]]
+    sha256 = "ca031dd5b36ab338d3b78d332f5633870fd7361420d56e710c3e59655eaf0b43"
+    url = "https://github.com/mwydmuch/ViZDoom/archive/1.1.8.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "ViZDoom"
 uuid = "befec858-9df8-11e8-00a8-a968a6be5c52"
-authors = ["Johanni Brea <johanni.brea@epfl.ch>", "Jun Tian <find_my_way@foxmail.com>"]
-version = "0.1.0"
+authors = ["Johanni Brea <johanni.brea@epfl.ch>", "Jun Tian <find_my_way@foxmail.com>", "IslandMan93 <islandman93@gmail.com>"]
+version = "0.1.1"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This package provides a wrapper around the [ViZDoom](https://github.com/mwydmuch
 
 ## How to install
 
-This package has only been tested on Ubuntu and Arch Linux with Julia 0.7/1.0 (and nightly). You need to install the necessary [dependencies](https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md#-linux) first (or, you can also check the [packages](https://github.com/JuliaReinforcementLearning/RLEnvViZDoom.jl/blob/master/.travis.yml) in the `.travis.yml` file). Then just add this package as usual:
+This package has only been tested on Ubuntu and Arch Linux with Julia 1.0/1.6 (and nightly). You need to install the necessary [dependencies](https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md#-linux) first (or, you can also check the [packages](https://github.com/JuliaReinforcementLearning/RLEnvViZDoom.jl/blob/master/.travis.yml) in the `.travis.yml` file). Then just add this package as usual:
 
 ```
-(v0.7) pkg> add ViZDoom
+(v1.6) pkg> add ViZDoom
 ```
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package provides a wrapper around the [ViZDoom](https://github.com/mwydmuch
 
 ## How to install
 
-This package has only been tested on Ubuntu and Arch Linux with Julia 1.0/1.6 (and nightly). You need to install the necessary [dependencies](https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md#-linux) first (or, you can also check the [packages](https://github.com/JuliaReinforcementLearning/RLEnvViZDoom.jl/blob/master/.travis.yml) in the `.travis.yml` file). Then just add this package as usual:
+This package has only been tested on Ubuntu (18.04+) and Arch Linux with Julia 1.0/1.6 (and nightly). You need to install the necessary [dependencies](https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md#-linux) first (or, you can also check the [packages](https://github.com/JuliaReinforcementLearning/RLEnvViZDoom.jl/blob/master/.travis.yml) in the `.travis.yml` file). It requires a gcc version with C++17 support. Then just add this package as usual:
 
 ```
 (v1.6) pkg> add ViZDoom

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-BinaryProvider
-CxxWrap

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,21 +1,21 @@
+using Artifacts
 using BinaryProvider
 using CxxWrap
 
-const tarball_url = "https://github.com/mwydmuch/ViZDoom/archive/1.1.6.tar.gz"
-const tarball_hash = "c127b97dec3365acbd0ff036b4011fc46c48df49b8fa984bc47acfb9303f7db3"
+vizdoom_artifact_dir = artifact"ViZDoom"
+vizdoom_dir = joinpath(vizdoom_artifact_dir, "ViZDoom-1.1.8")
+
+# Copy our lib_julia to the src dir and remove any old ones
 const deps_dir = @__DIR__
-const build_dir = joinpath(@__DIR__, "usr")
-const vizdoom_dir = joinpath(build_dir, "ViZDoom-1.1.6")
-const verbose = "--verbose" in ARGS
-
-install(tarball_url, tarball_hash; prefix=Prefix(build_dir), force=true, verbose=verbose)
-
-# replace old wrapper
 run(`rm -rf $(joinpath(vizdoom_dir, "src", "lib_julia"))`)
 run(`cp -r $(joinpath(deps_dir, "lib_julia")) $(joinpath(vizdoom_dir, "src"))`)
 
-const JLCxx_DIR = get(ENV, "JLCXX_DIR", joinpath(dirname(CxxWrap.jlcxx_path), "cmake", "JlCxx"))
+const JLCxx_DIR = get(ENV, "JLCXX_DIR", joinpath(CxxWrap.prefix_path(), "lib", "cmake", "JlCxx"))
 const cmake_cmd = `cmake -DJlCxx_DIR=$(JLCxx_DIR) -DBUILD_JULIA=ON -DJulia_EXECUTABLE=$(joinpath(Sys.BINDIR, "julia")) .`
 @info cmake_cmd
 cd(() -> run(cmake_cmd), vizdoom_dir)
 cd(() -> run(`make`), vizdoom_dir)
+
+# Copy freedoom2.wad into bin where everything else is.
+# The default config looks for ./freedoom2.wad so this allows for simpler configs
+run(`cp $(joinpath(vizdoom_dir, "src", "freedoom2.wad")) $(joinpath(vizdoom_dir, "bin"))`)

--- a/src/ViZDoom.jl
+++ b/src/ViZDoom.jl
@@ -1,7 +1,9 @@
 module ViZDoom
 
+using Artifacts
 using CxxWrap
-@wrapmodule(joinpath(@__DIR__, "..", "deps", "usr", "ViZDoom-1.1.6", "bin", "libvizdoomjl.so"), :ViZDoom)
+const vizdoom_artifact_dir = artifact"ViZDoom"
+@wrapmodule(joinpath(vizdoom_artifact_dir, "ViZDoom-1.1.8", "bin", "libvizdoomjl.so"))
 
 function __init__()
     @initcxx

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,4 +1,5 @@
-const scenario_dir = joinpath(@__DIR__, "..", "deps", "usr", "ViZDoom-1.1.6", "scenarios")
+const vizdoom_artifact_dir = artifact"ViZDoom"
+const scenario_dir = joinpath(vizdoom_artifact_dir, "ViZDoom-1.1.8", "scenarios")
 
 
 function get_scenario_path(s::AbstractString)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -4,6 +4,7 @@ ViZDoom.init(game)
 
 actions = [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]
 episodes = 1
+# example if running real time, you could use sleep(sleep_time)
 sleep_time = 1.0 / ViZDoom.DEFAULT_TICRATE
 
 for i in 1:episodes
@@ -12,9 +13,16 @@ for i in 1:episodes
 
     while !ViZDoom.is_episode_finished(game)
         state = ViZDoom.get_screen_buffer(game)
-        print(size(state))
+        screen_shape = ViZDoom.get_screen_width(game), ViZDoom.get_screen_height(game), ViZDoom.get_screen_channels(game)
+        print(size(state), screen_shape)
+        # example reshaping screen size
+        image_state = reshape(state, screen_shape)
         r = ViZDoom.make_action(game, rand(actions))
         println("Reward $r")
-        sleep(sleep_time)
+        # player is dead, most games have auto-respawn enabled
+        # this is the code to use if you don't enable it
+        if ViZDoom.is_player_dead(game)
+            ViZDoom.respawn_player(game)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,20 @@
 using ViZDoom
 using Test
 
-# include("basic.jl")
+# TODO: just check these exist instead of printing
+# Type tests
+println(ViZDoom.Mode)
+println(ViZDoom.ScreenFormat)
+println(ViZDoom.ScreenResolution)
+println(ViZDoom.AutomapMode)
+println(ViZDoom.Button)
+println(ViZDoom.Label)
+println(ViZDoom.ServerState)
+println(ViZDoom.DoomGame)
+# Cosnt tests
+@assert ViZDoom.MAX_PLAYERS == 16
+# Enum tests
+@assert typeof(ViZDoom.PLAYER) == ViZDoom.Mode
+
+# Basic test
+include("basic.jl")


### PR DESCRIPTION
Fixed issues with using the latest CxxWrap (v0.11.2) and switched to using Artifacts for ViZDoom source. I haven't fully tried to use this for experiments but it builds and the tests run (episodes + screen buffer + config, etc.). This also fixes issues with enums (or at least I tested they are correct) #7. Also bumped the version number to 0.1.1.

I can't figure out how to correctly get the labels object from GameState (line 300 ViZDoomJuliaModule). So I ended commenting that out. 