### PR TITLE
Throw error instead of segfault on buffer access

### DIFF
--- a/deps/lib_julia/ViZDoomJuliaModule.cpp
+++ b/deps/lib_julia/ViZDoomJuliaModule.cpp
@@ -450,8 +450,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
                     " with new_episode.");
             }
             return jlcxx::ArrayRef<uint8_t, 1>(
-                state->depthBuffer->data(),
-                 dg.getScreenWidth() * dg.getScreenHeight()); })
+                state->depthBuffer->data(), state->depthBuffer->size()
+            ); 
+        })
         .method("get_labels_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
             if (state == nullptr){
@@ -461,8 +462,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
                     " with new_episode.");
             }
             return jlcxx::ArrayRef<uint8_t, 1>(
-                state->labelsBuffer->data(),
-                 dg.getScreenWidth() * dg.getScreenHeight()); })
+                state->labelsBuffer->data(), state->labelsBuffer->size()
+            ); 
+        })
         .method("get_automap_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
             if (state == nullptr){
@@ -472,8 +474,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
                     " with new_episode.");
             }
             return jlcxx::ArrayRef<uint8_t, 1>(
-                state->automapBuffer->data(),
-                 dg.getScreenWidth() * dg.getScreenHeight() * dg.getScreenChannels()); });
+                state->automapBuffer->data(), state->automapBuffer->size()
+            ); 
+        });
 
     mod.method("doom_tics_to_ms", doomTicsToMs);
     mod.method("ms_to_doom_tics", msToDoomTics);

--- a/deps/lib_julia/ViZDoomJuliaModule.cpp
+++ b/deps/lib_julia/ViZDoomJuliaModule.cpp
@@ -427,26 +427,50 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
         .method("get_screen_size", &DoomGame::getScreenSize)
         .method("get_screen_pitch", &DoomGame::getScreenPitch)
         .method("get_screen_format", &DoomGame::getScreenFormat)
-        // TODO:
-        //
-        //  1. null check
+        // NOTE: state can be nullptr at the end of game
+        // Throw a logic_error so Julia can get this exception instead of segfault
         .method("get_screen_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
+            if (state == nullptr){
+                throw std::logic_error("Calling a function that "
+                    "requires gameState when it is nullptr. "
+                    "This happens if the episode is finished but not re-initialized"
+                    " with new_episode.");
+            }
             return jlcxx::ArrayRef<uint8_t, 1>(
-                state->screenBuffer->data(),
-                 dg.getScreenWidth() * dg.getScreenHeight() * dg.getScreenChannels()); })
+                state->screenBuffer->data(), state->screenBuffer->size()
+            );
+        })
         .method("get_depth_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
+            if (state == nullptr){
+                throw std::logic_error("Calling a function that "
+                    "requires gameState when it is nullptr. "
+                    "This happens if the episode is finished but not re-initialized"
+                    " with new_episode.");
+            }
             return jlcxx::ArrayRef<uint8_t, 1>(
                 state->depthBuffer->data(),
                  dg.getScreenWidth() * dg.getScreenHeight()); })
         .method("get_labels_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
+            if (state == nullptr){
+                throw std::logic_error("Calling a function that "
+                    "requires gameState when it is nullptr. "
+                    "This happens if the episode is finished but not re-initialized"
+                    " with new_episode.");
+            }
             return jlcxx::ArrayRef<uint8_t, 1>(
                 state->labelsBuffer->data(),
                  dg.getScreenWidth() * dg.getScreenHeight()); })
         .method("get_automap_buffer", [](DoomGame &dg) {
             GameStatePtr state = dg.getState();
+            if (state == nullptr){
+                throw std::logic_error("Calling a function that "
+                    "requires gameState when it is nullptr. "
+                    "This happens if the episode is finished but not re-initialized"
+                    " with new_episode.");
+            }
             return jlcxx::ArrayRef<uint8_t, 1>(
                 state->automapBuffer->data(),
                  dg.getScreenWidth() * dg.getScreenHeight() * dg.getScreenChannels()); });

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,5 +16,37 @@ println(ViZDoom.DoomGame)
 # Enum tests
 @assert typeof(ViZDoom.PLAYER) == ViZDoom.Mode
 
+# trying to access before init throws load error
+try
+    game = basic_game(;window_visible=false)
+    # this should throw
+    ViZDoom.get_screen_buffer(game)
+catch LoadError
+end
+
+# this should throw nullptr: accessing after a game is over without reset
+game = basic_game(;window_visible=false)
+ViZDoom.init(game)
+ViZDoom.new_episode(game)
+while !ViZDoom.is_episode_finished(game)
+    ViZDoom.make_action(game, [1.])
+end
+try
+    ViZDoom.get_screen_buffer(game)
+catch LoadError
+end
+try
+    ViZDoom.get_automap_buffer(game)
+catch LoadError
+end
+try
+    ViZDoom.get_depth_buffer(game)
+catch LoadError
+end
+try
+    ViZDoom.get_labels_buffer(game)
+catch LoadError
+end
+
 # Basic test
 include("basic.jl")


### PR DESCRIPTION
Fixes #14. Now all get_*_buffer methods will throw a Julia LoadError instead of segfaulting.